### PR TITLE
refactor_buffer_usage_node6 - Refactor deprectae method new Buffer in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # truncate-stream changelog
 
+## 1.0.2 (2016/10/21)
+
+  - change deprecated method `new Buffer` to `Buffer.alloc`
+
 ## 1.0.1 (2014/11/12)
 
   - fix streams that emit more than 1 chunk

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truncate-stream",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "stream which truncates input after N bytes",
   "main": "truncate-stream.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ describe('truncate-stream', function() {
   it('should not truncate a stream that was smaller than the maxBytes', function (done) {
     var source = new stream.Readable();
     source._read = function () {
-      this.push(new Buffer(100));
+      this.push(typeof(Buffer.alloc) == 'function' ? Buffer.alloc(100) : new Buffer(100)); // support for node 6 Buffer.alloc method
       this.push(null);
     };
     var truncate = new TruncateStream({maxBytes: 1024});


### PR DESCRIPTION
In node 6 new Buffer is deprecated and needs to be replaced with Buffer.alloc
